### PR TITLE
Add CI badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # Wangkanai Ledger
 
 Wangkanai Accounting General Ledger
+
+[![ledger-ci](https://github.com/wangkanai/ledger/actions/workflows/dotnet.yml/badge.svg)](https://github.com/wangkanai/ledger/actions/workflows/dotnet.yml)


### PR DESCRIPTION
Include a badge for the project's CI status to provide a quick visual indicator of the build status. Improves transparency and accessibility for contributors and users.