### PR TITLE
Update package versions and reorder dependencies

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -26,14 +26,14 @@
 
 	<!-- xUnit Tests-->
 	<ItemGroup Condition="$(MSBuildProjectName.Contains('Tests'))">
-		<PackageReference Include="Microsoft.AspNetCore.TestHost"/>
 		<PackageReference Include="Microsoft.NET.Test.Sdk"/>
-		<PackageReference Include="Moq"/>
+		<PackageReference Include="Microsoft.AspNetCore.TestHost"/>
 		<PackageReference Include="xunit"/>
 		<PackageReference Include="xunit.runner.visualstudio"/>
 		<PackageReference Include="coverlet.collector"/>
 		<PackageReference Include="coverlet.msbuild"/>
 		<PackageReference Include="FluentAssertions"/>
+		<PackageReference Include="Moq"/>
 	</ItemGroup>
 
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,23 +1,23 @@
 <Project>
-  <PropertyGroup>
-    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
-  <ItemGroup>
-    <!--sourcelink-->
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-    <!--tests -->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="8.0.5" />
-    <PackageVersion Include="Moq" Version="4.20.72" />
-    <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" PrivateAssets="all" />
-    <PackageVersion Include="coverlet.collector" Version="6.0.2" PrivateAssets="all" />
-    <PackageVersion Include="coverlet.msbuild" Version="6.0.2" PrivateAssets="all" />
-    <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <!--benchmark-->
-    <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
+	<PropertyGroup>
+		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+	</PropertyGroup>
+	<ItemGroup>
+		<!--source link-->
+		<PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
+		<!--tests-->
+		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+		<PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.3" />
+		<PackageVersion Include="xunit" Version="2.9.3" />
+		<PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" PrivateAssets="All" />
+		<PackageVersion Include="coverlet.collector" Version="6.0.4" PrivateAssets="All" />
+		<PackageVersion Include="coverlet.msbuild" Version="6.0.4" PrivateAssets="All" />
+		<PackageVersion Include="FluentAssertions" Version="8.2.0" />
+		<PackageVersion Include="Moq" Version="4.20.72" />
+		<!--benchmark-->
+		<PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
 		<!--wangkanai-->
 		<PackageVersion Include="Wangkanai.System" Version="5.1.0" />
 		<PackageVersion Include="Wangkanai.Domain" Version="4.6.0" />
-  </ItemGroup>
+	</ItemGroup>
 </Project>


### PR DESCRIPTION
Reordered package references in `Directory.Build.targets` and updated several package versions in `Directory.Packages.props` for improved clarity and compatibility. Adjustments include upgrading Microsoft.AspNetCore.TestHost, FluentAssertions, coverlet packages, and BenchmarkDotNet.

This pull request includes updates to package references in the `Directory.Build.targets` and `Directory.Packages.props` files. The main changes involve reordering and updating the versions of several package dependencies.

### Updates to package references:

* [`Directory.Build.targets`](diffhunk://#diff-50e91c82311ea26f2a73202525dfdf2b0a89c178ee666b2bf3ad4c84ac4c06dcL29-R36): Reordered the `PackageReference` entries for `Microsoft.AspNetCore.TestHost` and `Moq` to maintain alphabetical order.

* [`Directory.Packages.props`](diffhunk://#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156L10-R18): Updated the version of `Microsoft.AspNetCore.TestHost` to `9.0.3`, `coverlet.collector` to `6.0.4`, `coverlet.msbuild` to `6.0.4`, `FluentAssertions` to `8.2.0`, and `BenchmarkDotNet` to `0.14.0`. Reordered the `PackageVersion` entries to maintain consistency.