### PR TITLE
Update package versions in Directory.Packages.props

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,10 +6,10 @@
     <!--source link-->
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <!--tests-->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.3" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.5" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.0.2" PrivateAssets="All" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" PrivateAssets="All" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" PrivateAssets="All" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" PrivateAssets="All" />
     <PackageVersion Include="FluentAssertions" Version="8.2.0" />
@@ -18,6 +18,6 @@
     <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
     <!--wangkanai-->
     <PackageVersion Include="Wangkanai.System" Version="5.4.0" />
-    <PackageVersion Include="Wangkanai.Domain" Version="4.6.0" />
+    <PackageVersion Include="Wangkanai.Domain" Version="5.0.0-Beta-4" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Upgraded multiple package dependencies to their latest versions, including Microsoft.NET.Test.Sdk, Microsoft.AspNetCore.TestHost, xUnit, and Wangkanai.Domain. This improves compatibility, fixes potential issues, and ensures the project uses the most recent features and bug fixes.

This pull request updates several package dependencies in the `Directory.Packages.props` file to their latest versions, improving compatibility and access to newer features.

### Dependency Updates:

* Updated `Microsoft.NET.Test.Sdk` from version `17.13.0` to `17.14.0` and `Microsoft.AspNetCore.TestHost` from version `9.0.3` to `9.0.5`.
* Updated `xunit.runner.visualstudio` from version `3.0.2` to `3.1.0`.
* Updated `Wangkanai.Domain` from version `4.6.0` to `5.0.0-Beta-4`.