### PR TITLE
Update parameter and logic for publishing in sign.ps1

### DIFF
--- a/sign.ps1
+++ b/sign.ps1
@@ -1,6 +1,6 @@
 param(
-	[Parameter(mandatory = $false)]
-	[bool]$dryrun = $false,
+    [Parameter(mandatory = $false)]
+    [bool]$publish = $true,
 	[Parameter(mandatory = $false)]
 	[string]$certicate = "Open Source Developer, Sarin Na Wangkanai"
 )
@@ -26,7 +26,7 @@ dotnet pack -c Release -tl -o .\artifacts --include-symbols -p:SymbolPackageForm
 dotnet nuget sign .\artifacts\*.nupkg  -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $certicate -o .\signed
 dotnet nuget sign .\artifacts\*.snupkg -v normal --timestamper http://timestamp.digicert.com --certificate-subject-name $certicate -o .\signed
 
-if ($dryrun) {
+if (!$publish) {
 	Write-Host "Dryrun: Cryptography" -ForegroundColor Yellow;
 	exit;
 }


### PR DESCRIPTION
Replaces the 'dryrun' parameter with 'publish' for clarity and adjusts the conditional logic accordingly. This improves the script's readability and aligns with its intended functionality.