### PR TITLE
Update package versions

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -15,23 +15,22 @@
     <PackageVersion Include="Microsoft.AspNetCore.Components.WebAssembly.Server" Version="$(FrameworkVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="$(FrameworkVersion)" />
     <PackageVersion Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="$(FrameworkVersion)" />
+    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="$(FrameworkVersion)" />
     <!--efcore-->
 		<PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="$(FrameworkVersion)" PrivateAssets="all" />
 		<PackageVersion Include="Microsoft.EntityFrameworkCore.Tools" Version="$(FrameworkVersion)" PrivateAssets="all" />
 		<PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="$(FrameworkVersion)" />
 		<PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
     <!--tests-->
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.0" />
-    <PackageVersion Include="Microsoft.AspNetCore.TestHost" Version="9.0.5" />
-    <PackageVersion Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.4" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageVersion Include="xunit" Version="2.9.3" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.0" PrivateAssets="All" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" PrivateAssets="All" />
     <PackageVersion Include="coverlet.collector" Version="6.0.4" PrivateAssets="All" />
     <PackageVersion Include="coverlet.msbuild" Version="6.0.4" PrivateAssets="All" />
-    <PackageVersion Include="FluentAssertions" Version="8.2.0" />
+    <PackageVersion Include="FluentAssertions" Version="8.3.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <!--benchmark-->
-    <PackageVersion Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageVersion Include="BenchmarkDotNet" Version="0.15.2" />
     <!--wangkanai-->
     <PackageVersion Include="Wangkanai.System" Version="5.7.0" />
     <PackageVersion Include="Wangkanai.Domain" Version="5.0.0-Beta-7" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,6 @@
   </PropertyGroup>
   <ItemGroup>
     <!--sourcelink-->
-    <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.6" />
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
     <!--frameworks-->
     <!--extensions-->


### PR DESCRIPTION
This pull request updates several package versions in the `Directory.Packages.props` file to ensure compatibility and improve functionality. It also reintroduces the `Microsoft.AspNetCore.TestHost` package with the framework version.

### Package Updates:
* Updated `Microsoft.NET.Test.Sdk` from version `17.14.0` to `17.14.1`.
* Updated `xunit.runner.visualstudio` from version `3.1.0` to `3.1.1`.
* Updated `FluentAssertions` from version `8.2.0` to `8.3.0`.
* Updated `BenchmarkDotNet` from version `0.14.0` to `0.15.2`.

### Package Reintroduction:
* Reintroduced `Microsoft.AspNetCore.TestHost` with the framework version, replacing the previously hardcoded version `9.0.5`.